### PR TITLE
Add Bootstrap shorts2 viewer with offcanvas comments

### DIFF
--- a/shorts/api/comment_add.php
+++ b/shorts/api/comment_add.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['error' => 'POST required']);
+    exit;
+}
+$short_id = (int)($_POST['short_id'] ?? 0);
+$username = trim($_POST['username'] ?? '');
+$comment = trim($_POST['comment'] ?? '');
+if (!$short_id || $username === '' || $comment === '') {
+    echo json_encode(['error' => 'Invalid input']);
+    exit;
+}
+if (strlen($username) > 40 || strlen($comment) > 300) {
+    echo json_encode(['error' => 'Too long']);
+    exit;
+}
+$stmt = $conn->prepare('INSERT INTO comments(short_id, username, comment, time) VALUES (?,?,?, NOW())');
+$stmt->bind_param('iss', $short_id, $username, $comment);
+$stmt->execute();
+$id = $stmt->insert_id;
+$stmt->close();
+$stmt = $conn->prepare('SELECT id, username, comment, time FROM comments WHERE id = ?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$row = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+$row['username'] = htmlspecialchars($row['username']);
+$row['comment'] = htmlspecialchars($row['comment']);
+echo json_encode($row);
+?>

--- a/shorts/api/comments_list.php
+++ b/shorts/api/comments_list.php
@@ -1,0 +1,19 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+$short_id = (int)($_GET['short_id'] ?? 0);
+$limit = (int)($_GET['limit'] ?? 50);
+if (!$short_id) { echo json_encode(['items'=>[]]); exit; }
+$stmt = $conn->prepare('SELECT id, username, comment, time FROM comments WHERE short_id = ? ORDER BY time DESC LIMIT ?');
+$stmt->bind_param('ii', $short_id, $limit);
+$stmt->execute();
+$result = $stmt->get_result();
+$items = [];
+while ($row = $result->fetch_assoc()) {
+    $row['username'] = htmlspecialchars($row['username']);
+    $row['comment'] = htmlspecialchars($row['comment']);
+    $items[] = $row;
+}
+$stmt->close();
+echo json_encode(['items' => $items]);
+?>

--- a/shorts/api/like.php
+++ b/shorts/api/like.php
@@ -1,0 +1,20 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['error' => 'POST required']);
+    exit;
+}
+$short_id = (int)($_POST['short_id'] ?? 0);
+if (!$short_id) { echo json_encode(['error' => 'Invalid id']); exit; }
+$stmt = $conn->prepare('UPDATE shorts SET likes_count = likes_count + 1 WHERE id = ?');
+$stmt->bind_param('i', $short_id);
+$stmt->execute();
+$stmt->close();
+$stmt = $conn->prepare('SELECT likes_count FROM shorts WHERE id = ?');
+$stmt->bind_param('i', $short_id);
+$stmt->execute();
+$likes = $stmt->get_result()->fetch_assoc()['likes_count'] ?? 0;
+$stmt->close();
+echo json_encode(['ok' => true, 'likes_count' => (int)$likes]);
+?>

--- a/shorts/api/shorts_list.php
+++ b/shorts/api/shorts_list.php
@@ -1,0 +1,24 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+$page = max(1, (int)($_GET['page'] ?? 1));
+$page_size = (int)($_GET['page_size'] ?? 10);
+$page_size = $page_size > 20 ? 20 : $page_size;
+$offset = ($page - 1) * $page_size;
+$stmt = $conn->prepare('SELECT id, link, likes_count, time FROM shorts ORDER BY time DESC LIMIT ?, ?');
+$stmt->bind_param('ii', $offset, $page_size);
+$stmt->execute();
+$result = $stmt->get_result();
+$items = [];
+while ($row = $result->fetch_assoc()) {
+    $items[] = $row;
+}
+$stmt->close();
+// check if more items exist
+$stmt = $conn->prepare('SELECT COUNT(*) as cnt FROM shorts');
+$stmt->execute();
+$total = $stmt->get_result()->fetch_assoc()['cnt'];
+$stmt->close();
+$has_more = ($offset + $page_size) < $total;
+echo json_encode(['items' => $items, 'has_more' => $has_more]);
+?>

--- a/shorts/assets/app.js
+++ b/shorts/assets/app.js
@@ -1,0 +1,189 @@
+let page=1,pageSize=10,loading=false,hasMore=true;
+let soundOn=localStorage.getItem('soundOn')==='1';
+const feed=document.getElementById('feed');
+const sentinel=document.getElementById('sentinel');
+const template=document.getElementById('slide-template');
+
+async function fetchShorts(){
+  if(loading||!hasMore) return;
+  loading=true;
+  const res=await fetch(`${API.shorts}?page=${page}&page_size=${pageSize}`);
+  const data=await res.json();
+  data.items.forEach(item=>{
+    const slide=createSlide(item);
+    feed.appendChild(slide);
+    observeSlide(slide);
+  });
+  hasMore=data.has_more;
+  page++;
+  loading=false;
+}
+
+function parseYtId(link){
+  try{
+    const url=new URL(link,location.href);
+    if(url.hostname.includes('youtu.be')) return url.pathname.split('/')[1];
+    if(url.pathname.includes('/shorts/')) return url.pathname.split('/shorts/')[1];
+    if(url.searchParams.get('v')) return url.searchParams.get('v');
+    return link;
+  }catch(e){return link;}
+}
+
+function createSlide(item){
+  const frag=template.content.cloneNode(true);
+  const slide=frag.querySelector('.slide');
+  slide.dataset.id=item.id;
+  const wrap=slide.querySelector('.video-wrap');
+  wrap.dataset.ytid=parseYtId(item.link);
+  slide.querySelector('.like-count').textContent=item.likes_count;
+  const likeBtn=slide.querySelector('.like-btn');
+  if(localStorage.getItem('liked:'+item.id)) likeBtn.dataset.liked="true";
+  likeBtn.addEventListener('click',()=>like(item.id,slide,likeBtn));
+  const volBtn=slide.querySelector('.volume-btn');
+  updateVolumeBtn(volBtn);
+  volBtn.addEventListener('click',toggleSound);
+  const commentBtn=slide.querySelector('.comment-btn');
+  const commentsEl=slide.querySelector('.comments');
+  const closeBtn=commentsEl.querySelector('.comments-close');
+  function toggleComments(){
+    const open=commentsEl.dataset.open==='true';
+    commentsEl.dataset.open=!open;
+    commentsEl.setAttribute('aria-expanded',(!open).toString());
+    if(!open) loadComments(item.id,commentsEl);
+  }
+  commentBtn.addEventListener('click',toggleComments);
+  closeBtn.addEventListener('click',toggleComments);
+  const form=slide.querySelector('.comment-form');
+  form.addEventListener('submit',e=>{
+    e.preventDefault();
+    const username=form.username.value.trim();
+    const comment=form.comment.value.trim();
+    if(!username||!comment) return;
+    postComment(item.id,username,comment,commentsEl);
+    form.reset();
+  });
+  return slide;
+}
+
+async function like(id,slide,btn){
+  if(localStorage.getItem('liked:'+id)) return;
+  localStorage.setItem('liked:'+id,'1');
+  btn.dataset.liked="true";
+  const countEl=slide.querySelector('.like-count');
+  countEl.textContent=parseInt(countEl.textContent)+1;
+  const res=await fetch(API.like,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:`short_id=${id}`});
+  const data=await res.json();
+  if(data.likes_count!==undefined) countEl.textContent=data.likes_count;
+}
+
+async function loadComments(id,container){
+  const list=container.querySelector('.comment-list');
+  list.innerHTML='';
+  const res=await fetch(`${API.comments}?short_id=${id}`);
+  const data=await res.json();
+  data.items.forEach(c=>{
+    const li=document.createElement('li');
+    li.textContent=`${c.username}: ${c.comment}`;
+    list.appendChild(li);
+  });
+}
+
+async function postComment(id,username,comment,container){
+  const list=container.querySelector('.comment-list');
+  const body=`short_id=${id}&username=${encodeURIComponent(username)}&comment=${encodeURIComponent(comment)}`;
+  const res=await fetch(API.commentAdd,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body});
+  const data=await res.json();
+  if(data.id){
+    const li=document.createElement('li');
+    li.textContent=`${data.username}: ${data.comment}`;
+    list.prepend(li);
+  }
+}
+
+function sendCommand(iframe,cmd){
+  iframe.contentWindow.postMessage(JSON.stringify({event:'command',func:cmd,args:[]}),'*');
+}
+function setActive(slide){
+  const wrap=slide.querySelector('.video-wrap');
+  const ytid=wrap.dataset.ytid;
+  let iframe=wrap.querySelector('iframe');
+  if(!iframe){
+    iframe=document.createElement('iframe');
+    iframe.setAttribute('allow','autoplay; encrypted-media');
+    iframe.setAttribute('allowfullscreen','');
+    iframe.setAttribute('loading','lazy');
+    iframe.src=`https://www.youtube.com/embed/${ytid}?enablejsapi=1&playsinline=1&controls=0&rel=0&modestbranding=1&loop=1&playlist=${ytid}&autoplay=1&mute=${soundOn?0:1}`;
+    iframe.addEventListener('load',()=>{
+      sendCommand(iframe,'playVideo');
+    });
+    wrap.appendChild(iframe);
+  }else{
+    sendCommand(iframe,soundOn?'unMute':'mute');
+    sendCommand(iframe,'playVideo');
+  }
+}
+function clearActive(slide){
+  const iframe=slide.querySelector('iframe');
+  if(iframe) sendCommand(iframe,'pauseVideo');
+}
+
+const videoObserver=new IntersectionObserver(entries=>{
+  entries.forEach(entry=>{
+    if(entry.isIntersecting&&entry.intersectionRatio>0.7){
+      setActive(entry.target);
+    }else{
+      clearActive(entry.target);
+    }
+  });
+},{threshold:0.7});
+
+const activeObserver=new IntersectionObserver(entries=>{
+  entries.forEach(entry=>{
+    if(entry.isIntersecting&&entry.intersectionRatio>0.8){
+      document.querySelectorAll('.slide').forEach(s=>s.classList.remove('slide--active'));
+      entry.target.classList.add('slide--active');
+    }
+  });
+},{threshold:0.8});
+
+function observeSlide(slide){
+  videoObserver.observe(slide);
+  activeObserver.observe(slide);
+}
+
+const sentinelObserver=new IntersectionObserver(entries=>{
+  if(entries[0].isIntersecting) fetchShorts();
+});
+sentinelObserver.observe(sentinel);
+
+document.getElementById('next-btn').addEventListener('click',nextSlide);
+document.getElementById('prev-btn').addEventListener('click',prevSlide);
+document.addEventListener('keydown',e=>{
+  if(e.key==='ArrowDown') nextSlide();
+  if(e.key==='ArrowUp') prevSlide();
+});
+
+function updateVolumeBtn(btn){
+  btn.textContent=soundOn?'🔊':'🔇';
+}
+function toggleSound(){
+  soundOn=!soundOn;
+  localStorage.setItem('soundOn',soundOn?'1':'0');
+  document.querySelectorAll('.volume-btn').forEach(updateVolumeBtn);
+  const active=document.querySelector('.slide--active');
+  if(active){
+    const iframe=active.querySelector('iframe');
+    if(iframe) sendCommand(iframe,soundOn?'unMute':'mute');
+  }
+}
+
+function nextSlide(){
+  const active=document.querySelector('.slide--active');
+  if(active&&active.nextElementSibling) active.nextElementSibling.scrollIntoView({behavior:'smooth'});
+}
+function prevSlide(){
+  const active=document.querySelector('.slide--active');
+  if(active&&active.previousElementSibling) active.previousElementSibling.scrollIntoView({behavior:'smooth'});
+}
+
+fetchShorts();

--- a/shorts/assets/style.css
+++ b/shorts/assets/style.css
@@ -1,0 +1,93 @@
+:root{
+  --bg:#0e0e10;
+  --surface:#18181b;
+  --surface-hover:#27272a;
+  --accent:#ff2255;
+  --text:#ffffff;
+  --overlay:linear-gradient(180deg,rgba(0,0,0,.6) 0%,rgba(0,0,0,0) 40%,rgba(0,0,0,0) 60%,rgba(0,0,0,.6) 100%);
+}
+*{box-sizing:border-box}
+html,body{
+  margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  overflow:hidden;
+}
+.topbar{
+  position:fixed;top:0;left:0;right:0;height:56px;
+  display:flex;justify-content:space-between;align-items:center;
+  padding:0 1rem;background:rgba(24,24,27,.7);
+  backdrop-filter:blur(8px);
+  box-shadow:0 2px 8px rgba(0,0,0,.6);z-index:10;
+}
+.topbar h1{margin:0;font-size:1.3rem;font-weight:600}
+.nav-buttons button{
+  background:var(--surface-hover);color:var(--text);
+  border:none;padding:.4rem .8rem;border-radius:8px;font-size:1.2rem;
+  cursor:pointer;transition:background .2s;
+}
+.nav-buttons button:hover{background:#3f3f46}
+main#feed{
+  scroll-snap-type:y mandatory;height:100vh;overflow-y:scroll;
+  scroll-behavior:smooth;
+  -ms-overflow-style:none;scrollbar-width:none;
+}
+main#feed::-webkit-scrollbar{display:none}
+.slide{
+  min-height:100vh;position:relative;display:grid;place-items:center;
+  scroll-snap-align:start;background:var(--bg);
+}
+.slide::before{
+  content:"";position:absolute;inset:0;pointer-events:none;background:var(--overlay);
+}
+.video-wrap{
+  position:absolute;inset:0;overflow:hidden;background:#000;
+  display:flex;align-items:center;justify-content:center;
+}
+.video-wrap iframe{
+  position:absolute;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  width:100vw;
+  height:calc(100vw*16/9);
+  border:none;
+}
+.ui{
+  position:absolute;right:1rem;bottom:4rem;display:flex;flex-direction:column;gap:1rem;
+}
+.ui button{
+  background:rgba(24,24,27,.7);border:none;
+  border-radius:50%;width:56px;height:56px;color:var(--text);
+  font-size:1.4rem;display:flex;align-items:center;justify-content:center;
+  cursor:pointer;transition:transform .2s,background .2s;
+  box-shadow:0 4px 10px rgba(0,0,0,.6);
+  backdrop-filter:blur(8px);
+}
+.ui button:hover{transform:scale(1.1);background:rgba(39,39,42,.7)}
+.like-btn[data-liked="true"] .heart{color:var(--accent)}
+.volume-btn{font-size:1.6rem}
+.comments{
+  position:absolute;left:0;right:0;bottom:0;background:var(--surface);
+  border-top-left-radius:12px;border-top-right-radius:12px;
+  transform:translateY(100%);transition:transform .25s;
+  padding:1rem;max-height:65vh;display:flex;flex-direction:column;
+}
+.comments-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:.5rem;font-weight:600}
+.comments-close{background:none;border:none;color:var(--text);font-size:1.5rem;cursor:pointer}
+.comments[data-open="true"]{transform:translateY(0)}
+.comment-list{list-style:none;margin:0;padding:0;overflow-y:auto;flex:1}
+.comment-list::-webkit-scrollbar{width:6px}
+.comment-list::-webkit-scrollbar-thumb{background:#3f3f46;border-radius:3px}
+.comment-list li{padding:.5rem 0;border-bottom:1px solid rgba(255,255,255,.1)}
+.comment-form{display:flex;flex-direction:column;gap:.5rem}
+.comment-form input,.comment-form textarea{
+  width:100%;padding:.6rem .75rem;border-radius:8px;
+  border:1px solid rgba(255,255,255,.1);background:var(--bg);color:var(--text);
+}
+.comment-form button{
+  align-self:flex-end;padding:.6rem 1.2rem;background:var(--accent);
+  color:var(--text);border:none;border-radius:8px;font-weight:600;
+  cursor:pointer;transition:background .2s;
+}
+.comment-form button:hover{background:#e8194a}
+:focus{outline:2px solid var(--accent);outline-offset:2px}

--- a/shorts/db.php
+++ b/shorts/db.php
@@ -1,0 +1,12 @@
+<?php
+$host = 'localhost';
+$user = 'root';
+$pass = '';
+$db   = 'shorts';
+
+$conn = new mysqli($host, $user, $pass, $db);
+if ($conn->connect_error) {
+    die('Connection failed: ' . $conn->connect_error);
+}
+$conn->set_charset('utf8mb4');
+?>

--- a/shorts/index.php
+++ b/shorts/index.php
@@ -1,0 +1,52 @@
+<?php require_once 'db.php'; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shorts Viewer</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<header class="topbar">
+    <h1>Shorts</h1>
+    <div class="nav-buttons">
+        <button id="prev-btn" aria-label="Previous">↑</button>
+        <button id="next-btn" aria-label="Next">↓</button>
+    </div>
+</header>
+<main id="feed" aria-live="polite"></main>
+<div id="sentinel"></div>
+<template id="slide-template">
+    <section class="slide" data-id="">
+        <div class="video-wrap"></div>
+        <div class="ui">
+            <button class="volume-btn" aria-label="Toggle sound">🔇</button>
+            <button class="like-btn" aria-label="Like"><span class="heart">❤️</span> <span class="like-count"></span></button>
+            <button class="comment-btn" aria-label="Comments">💬</button>
+        </div>
+        <div class="comments" data-open="false" aria-expanded="false">
+            <div class="comments-header">
+                <span>Comments</span>
+                <button class="comments-close" aria-label="Close">×</button>
+            </div>
+            <ul class="comment-list"></ul>
+            <form class="comment-form">
+                <input type="text" name="username" maxlength="40" placeholder="Name" required>
+                <textarea name="comment" maxlength="300" placeholder="Comment" required></textarea>
+                <button type="submit">Post</button>
+            </form>
+        </div>
+    </section>
+</template>
+<script>
+const API = {
+    shorts: 'api/shorts_list.php',
+    like: 'api/like.php',
+    comments: 'api/comments_list.php',
+    commentAdd: 'api/comment_add.php'
+};
+</script>
+<script src="assets/app.js"></script>
+</body>
+</html>

--- a/shorts2/api/comment_add.php
+++ b/shorts2/api/comment_add.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['error' => 'POST required']);
+    exit;
+}
+$short_id = (int)($_POST['short_id'] ?? 0);
+$username = trim($_POST['username'] ?? '');
+$comment = trim($_POST['comment'] ?? '');
+if (!$short_id || $username === '' || $comment === '') {
+    echo json_encode(['error' => 'Invalid input']);
+    exit;
+}
+if (strlen($username) > 40 || strlen($comment) > 300) {
+    echo json_encode(['error' => 'Too long']);
+    exit;
+}
+$stmt = $conn->prepare('INSERT INTO comments(short_id, username, comment, time) VALUES (?,?,?, NOW())');
+$stmt->bind_param('iss', $short_id, $username, $comment);
+$stmt->execute();
+$id = $stmt->insert_id;
+$stmt->close();
+$stmt = $conn->prepare('SELECT id, username, comment, time FROM comments WHERE id = ?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$row = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+$row['username'] = htmlspecialchars($row['username']);
+$row['comment'] = htmlspecialchars($row['comment']);
+echo json_encode($row);
+?>

--- a/shorts2/api/comments_list.php
+++ b/shorts2/api/comments_list.php
@@ -1,0 +1,19 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+$short_id = (int)($_GET['short_id'] ?? 0);
+$limit = (int)($_GET['limit'] ?? 50);
+if (!$short_id) { echo json_encode(['items'=>[]]); exit; }
+$stmt = $conn->prepare('SELECT id, username, comment, time FROM comments WHERE short_id = ? ORDER BY time DESC LIMIT ?');
+$stmt->bind_param('ii', $short_id, $limit);
+$stmt->execute();
+$result = $stmt->get_result();
+$items = [];
+while ($row = $result->fetch_assoc()) {
+    $row['username'] = htmlspecialchars($row['username']);
+    $row['comment'] = htmlspecialchars($row['comment']);
+    $items[] = $row;
+}
+$stmt->close();
+echo json_encode(['items' => $items]);
+?>

--- a/shorts2/api/like.php
+++ b/shorts2/api/like.php
@@ -1,0 +1,20 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['error' => 'POST required']);
+    exit;
+}
+$short_id = (int)($_POST['short_id'] ?? 0);
+if (!$short_id) { echo json_encode(['error' => 'Invalid id']); exit; }
+$stmt = $conn->prepare('UPDATE shorts SET likes_count = likes_count + 1 WHERE id = ?');
+$stmt->bind_param('i', $short_id);
+$stmt->execute();
+$stmt->close();
+$stmt = $conn->prepare('SELECT likes_count FROM shorts WHERE id = ?');
+$stmt->bind_param('i', $short_id);
+$stmt->execute();
+$likes = $stmt->get_result()->fetch_assoc()['likes_count'] ?? 0;
+$stmt->close();
+echo json_encode(['ok' => true, 'likes_count' => (int)$likes]);
+?>

--- a/shorts2/api/shorts_list.php
+++ b/shorts2/api/shorts_list.php
@@ -1,0 +1,24 @@
+<?php
+header('Content-Type: application/json');
+require_once '../db.php';
+$page = max(1, (int)($_GET['page'] ?? 1));
+$page_size = (int)($_GET['page_size'] ?? 10);
+$page_size = $page_size > 20 ? 20 : $page_size;
+$offset = ($page - 1) * $page_size;
+$stmt = $conn->prepare('SELECT id, link, likes_count, time FROM shorts ORDER BY time DESC LIMIT ?, ?');
+$stmt->bind_param('ii', $offset, $page_size);
+$stmt->execute();
+$result = $stmt->get_result();
+$items = [];
+while ($row = $result->fetch_assoc()) {
+    $items[] = $row;
+}
+$stmt->close();
+// check if more items exist
+$stmt = $conn->prepare('SELECT COUNT(*) as cnt FROM shorts');
+$stmt->execute();
+$total = $stmt->get_result()->fetch_assoc()['cnt'];
+$stmt->close();
+$has_more = ($offset + $page_size) < $total;
+echo json_encode(['items' => $items, 'has_more' => $has_more]);
+?>

--- a/shorts2/assets/app.js
+++ b/shorts2/assets/app.js
@@ -1,0 +1,185 @@
+let page=1,pageSize=10,loading=false,hasMore=true;
+let soundOn=localStorage.getItem('soundOn')==='1';
+const feed=document.getElementById('feed');
+const sentinel=document.getElementById('sentinel');
+const template=document.getElementById('slide-template');
+const offcanvasEl=document.getElementById('commentsCanvas');
+const commentList=offcanvasEl.querySelector('.comment-list');
+const commentForm=offcanvasEl.querySelector('.comment-form');
+let currentCommentShortId=null;
+
+commentForm.addEventListener('submit',e=>{
+  e.preventDefault();
+  const username=commentForm.username.value.trim();
+  const comment=commentForm.comment.value.trim();
+  if(!username||!comment||currentCommentShortId===null) return;
+  postComment(currentCommentShortId,username,comment);
+  commentForm.reset();
+});
+
+async function fetchShorts(){
+  if(loading||!hasMore) return;
+  loading=true;
+  const res=await fetch(`${API.shorts}?page=${page}&page_size=${pageSize}`);
+  const data=await res.json();
+  data.items.forEach(item=>{
+    const slide=createSlide(item);
+    feed.appendChild(slide);
+    observeSlide(slide);
+  });
+  hasMore=data.has_more;
+  page++;
+  loading=false;
+}
+
+function parseYtId(link){
+  try{
+    const url=new URL(link,location.href);
+    if(url.hostname.includes('youtu.be')) return url.pathname.split('/')[1];
+    if(url.pathname.includes('/shorts/')) return url.pathname.split('/shorts/')[1];
+    if(url.searchParams.get('v')) return url.searchParams.get('v');
+    return link;
+  }catch(e){return link;}
+}
+
+function createSlide(item){
+  const frag=template.content.cloneNode(true);
+  const slide=frag.querySelector('.slide');
+  slide.dataset.id=item.id;
+  const wrap=slide.querySelector('.video-wrap');
+  wrap.dataset.ytid=parseYtId(item.link);
+  slide.querySelector('.like-count').textContent=item.likes_count;
+  const likeBtn=slide.querySelector('.like-btn');
+  if(localStorage.getItem('liked:'+item.id)) likeBtn.dataset.liked="true";
+  likeBtn.addEventListener('click',()=>like(item.id,slide,likeBtn));
+  const volBtn=slide.querySelector('.volume-btn');
+  updateVolumeBtn(volBtn);
+  volBtn.addEventListener('click',toggleSound);
+  const commentBtn=slide.querySelector('.comment-btn');
+  commentBtn.addEventListener('click',()=>{
+    currentCommentShortId=item.id;
+    loadComments(item.id);
+  });
+  return slide;
+}
+
+async function like(id,slide,btn){
+  if(localStorage.getItem('liked:'+id)) return;
+  localStorage.setItem('liked:'+id,'1');
+  btn.dataset.liked="true";
+  const countEl=slide.querySelector('.like-count');
+  countEl.textContent=parseInt(countEl.textContent)+1;
+  const res=await fetch(API.like,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:`short_id=${id}`});
+  const data=await res.json();
+  if(data.likes_count!==undefined) countEl.textContent=data.likes_count;
+}
+
+async function loadComments(id){
+  commentList.innerHTML='';
+  const res=await fetch(`${API.comments}?short_id=${id}`);
+  const data=await res.json();
+  data.items.forEach(c=>{
+    const li=document.createElement('li');
+    li.textContent=`${c.username}: ${c.comment}`;
+    commentList.appendChild(li);
+  });
+}
+
+async function postComment(id,username,comment){
+  const body=`short_id=${id}&username=${encodeURIComponent(username)}&comment=${encodeURIComponent(comment)}`;
+  const res=await fetch(API.commentAdd,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body});
+  const data=await res.json();
+  if(data.id){
+    const li=document.createElement('li');
+    li.textContent=`${data.username}: ${data.comment}`;
+    commentList.prepend(li);
+  }
+}
+
+function sendCommand(iframe,cmd){
+  iframe.contentWindow.postMessage(JSON.stringify({event:'command',func:cmd,args:[]}),'*');
+}
+function setActive(slide){
+  const wrap=slide.querySelector('.video-wrap');
+  const ytid=wrap.dataset.ytid;
+  let iframe=wrap.querySelector('iframe');
+  if(!iframe){
+    iframe=document.createElement('iframe');
+    iframe.setAttribute('allow','autoplay; encrypted-media');
+    iframe.setAttribute('allowfullscreen','');
+    iframe.setAttribute('loading','lazy');
+    iframe.src=`https://www.youtube.com/embed/${ytid}?enablejsapi=1&playsinline=1&controls=0&rel=0&modestbranding=1&loop=1&playlist=${ytid}&autoplay=1&mute=${soundOn?0:1}`;
+    iframe.addEventListener('load',()=>{
+      sendCommand(iframe,'playVideo');
+    });
+    wrap.appendChild(iframe);
+  }else{
+    sendCommand(iframe,soundOn?'unMute':'mute');
+    sendCommand(iframe,'playVideo');
+  }
+}
+function clearActive(slide){
+  const iframe=slide.querySelector('iframe');
+  if(iframe) sendCommand(iframe,'pauseVideo');
+}
+
+const videoObserver=new IntersectionObserver(entries=>{
+  entries.forEach(entry=>{
+    if(entry.isIntersecting&&entry.intersectionRatio>0.7){
+      setActive(entry.target);
+    }else{
+      clearActive(entry.target);
+    }
+  });
+},{threshold:0.7});
+
+const activeObserver=new IntersectionObserver(entries=>{
+  entries.forEach(entry=>{
+    if(entry.isIntersecting&&entry.intersectionRatio>0.8){
+      document.querySelectorAll('.slide').forEach(s=>s.classList.remove('slide--active'));
+      entry.target.classList.add('slide--active');
+    }
+  });
+},{threshold:0.8});
+
+function observeSlide(slide){
+  videoObserver.observe(slide);
+  activeObserver.observe(slide);
+}
+
+const sentinelObserver=new IntersectionObserver(entries=>{
+  if(entries[0].isIntersecting) fetchShorts();
+});
+sentinelObserver.observe(sentinel);
+
+document.getElementById('next-btn').addEventListener('click',nextSlide);
+document.getElementById('prev-btn').addEventListener('click',prevSlide);
+document.addEventListener('keydown',e=>{
+  if(e.key==='ArrowDown') nextSlide();
+  if(e.key==='ArrowUp') prevSlide();
+});
+
+function updateVolumeBtn(btn){
+  btn.textContent=soundOn?'🔊':'🔇';
+}
+function toggleSound(){
+  soundOn=!soundOn;
+  localStorage.setItem('soundOn',soundOn?'1':'0');
+  document.querySelectorAll('.volume-btn').forEach(updateVolumeBtn);
+  const active=document.querySelector('.slide--active');
+  if(active){
+    const iframe=active.querySelector('iframe');
+    if(iframe) sendCommand(iframe,soundOn?'unMute':'mute');
+  }
+}
+
+function nextSlide(){
+  const active=document.querySelector('.slide--active');
+  if(active&&active.nextElementSibling) active.nextElementSibling.scrollIntoView({behavior:'smooth'});
+}
+function prevSlide(){
+  const active=document.querySelector('.slide--active');
+  if(active&&active.previousElementSibling) active.previousElementSibling.scrollIntoView({behavior:'smooth'});
+}
+
+fetchShorts();

--- a/shorts2/assets/style.css
+++ b/shorts2/assets/style.css
@@ -1,0 +1,5 @@
+html,body{height:100%;margin:0;}
+#feed{height:100vh;overflow-y:scroll;scroll-snap-type:y mandatory;}
+.slide{height:100vh;scroll-snap-align:start;position:relative;display:flex;justify-content:center;align-items:center;background:#000;}
+.video-wrap iframe{width:100%;height:100%;border:0;}
+.ui{position:absolute;top:50%;right:1rem;transform:translateY(-50%);display:flex;flex-direction:column;gap:.5rem;}

--- a/shorts2/db.php
+++ b/shorts2/db.php
@@ -1,0 +1,12 @@
+<?php
+$host = 'localhost';
+$user = 'root';
+$pass = '';
+$db   = 'shorts';
+
+$conn = new mysqli($host, $user, $pass, $db);
+if ($conn->connect_error) {
+    die('Connection failed: ' . $conn->connect_error);
+}
+$conn->set_charset('utf8mb4');
+?>

--- a/shorts2/index.php
+++ b/shorts2/index.php
@@ -1,0 +1,64 @@
+<?php require_once 'db.php'; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Shorts Viewer</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body class="bg-dark text-light">
+<header class="navbar navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <span class="navbar-brand mb-0 h1">Shorts</span>
+        <div>
+            <button id="prev-btn" class="btn btn-outline-light me-2" aria-label="Previous">↑</button>
+            <button id="next-btn" class="btn btn-outline-light" aria-label="Next">↓</button>
+        </div>
+    </div>
+</header>
+<main id="feed" class="pt-5" aria-live="polite"></main>
+<div id="sentinel"></div>
+<template id="slide-template">
+    <section class="slide" data-id="">
+        <div class="video-wrap"></div>
+        <div class="ui">
+            <button class="volume-btn btn btn-light mb-2" aria-label="Toggle sound">🔇</button>
+            <button class="like-btn btn btn-light mb-2" aria-label="Like"><span class="heart">❤️</span> <span class="like-count"></span></button>
+            <button class="comment-btn btn btn-light" data-bs-toggle="offcanvas" data-bs-target="#commentsCanvas" aria-label="Comments">💬</button>
+        </div>
+    </section>
+</template>
+
+<div class="offcanvas offcanvas-end text-bg-dark" tabindex="-1" id="commentsCanvas">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Comments</h5>
+    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+  </div>
+  <div class="offcanvas-body">
+    <ul class="comment-list list-unstyled mb-3"></ul>
+    <form class="comment-form">
+      <div class="mb-3">
+        <input type="text" name="username" maxlength="40" class="form-control" placeholder="Name" required>
+      </div>
+      <div class="mb-3">
+        <textarea name="comment" maxlength="300" class="form-control" placeholder="Comment" required></textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">Post</button>
+    </form>
+  </div>
+</div>
+
+<script>
+const API = {
+    shorts: 'api/shorts_list.php',
+    like: 'api/like.php',
+    comments: 'api/comments_list.php',
+    commentAdd: 'api/comment_add.php'
+};
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="assets/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add new `shorts` feed with auto-playing YouTube slides, likes, and comments
- Polish comment drawer styling with header and close button
- Hide scrollbars and refine layout for cleaner mobile look
- Size embedded videos using viewport width so each short fills the screen

## Testing
- `php -l shorts/db.php`
- `php -l shorts/index.php`
- `php -l shorts/api/shorts_list.php`
- `php -l shorts/api/like.php`
- `php -l shorts/api/comments_list.php`
- `php -l shorts/api/comment_add.php`
- `node --check shorts/assets/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b43d1caa748330b20572bb2dd162f4