### PR TITLE
Add YouTube video info table page

### DIFF
--- a/shorts2/assets/video-table.js
+++ b/shorts2/assets/video-table.js
@@ -1,0 +1,40 @@
+const apiKey = "YOUR_API_KEY"; // Replace with your YouTube Data API key
+
+function extractVideoId(url) {
+  const match = url.match(/(?:v=|\.be\/)([\w-]{11})/);
+  return match ? match[1] : null;
+}
+
+async function fetchVideoInfo(id) {
+  const api = `https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics&id=${id}&key=${apiKey}`;
+  const res = await fetch(api);
+  const data = await res.json();
+  return data.items && data.items.length ? data.items[0] : null;
+}
+
+function addRow(video, id) {
+  const tbody = document.querySelector("#videoTable tbody");
+  const row = document.createElement("tr");
+  row.innerHTML = `
+    <td><img src="${video.snippet.thumbnails.default.url}" alt="thumb"></td>
+    <td>${video.snippet.title}</td>
+    <td>${video.statistics.likeCount || 0}</td>
+    <td>${video.statistics.commentCount || 0}</td>
+    <td>${new Date(video.snippet.publishedAt).toLocaleDateString()}</td>
+    <td><a href="https://youtu.be/${id}" target="_blank">Watch</a></td>
+  `;
+  tbody.appendChild(row);
+}
+
+const form = document.getElementById("addForm");
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const url = document.getElementById("videoUrl").value.trim();
+  const id = extractVideoId(url);
+  if (!id) return;
+  const video = await fetchVideoInfo(id);
+  if (video) {
+    addRow(video, id);
+  }
+  form.reset();
+});

--- a/shorts2/video_table.html
+++ b/shorts2/video_table.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Video Info Table</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-dark text-light p-3">
+    <h1 class="mb-3">YouTube Video Info</h1>
+    <form id="addForm" class="mb-3">
+      <div class="row g-2">
+        <div class="col">
+          <input
+            type="url"
+            id="videoUrl"
+            class="form-control"
+            placeholder="YouTube video URL"
+            required
+          />
+        </div>
+        <div class="col-auto">
+          <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+      </div>
+    </form>
+    <table class="table table-dark table-striped" id="videoTable">
+      <thead>
+        <tr>
+          <th scope="col">Thumbnail</th>
+          <th scope="col">Title</th>
+          <th scope="col">Likes</th>
+          <th scope="col">Comments</th>
+          <th scope="col">Uploaded</th>
+          <th scope="col">Link</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <script src="assets/video-table.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create standalone page to list YouTube videos in a table by URL
- fetch snippet and statistics to show thumbnail, counts and upload date

## Testing
- `npx prettier --check shorts2/video_table.html shorts2/assets/video-table.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5992d1a008330bc8dbd3d865686e6